### PR TITLE
feat!: use NumberFormat

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,11 +31,11 @@ humanNumber(1_000_000_000_000) // 1T
 humanNumber(1_500_000_000_000) // 1.5T
 ```
 
-You can pass a mapper as second parameter:
+You can pass a locale as second parameter. `en-US` is used by default:
 
 ```js
 const humanNumber = require('human-number')
-humanNumber(100, n => Number.parseFloat(n).toFixed(1)) // '100.0'
+humanNumber(1_500, 'es-ES') // '1,5 mil'
 ```
 
 ## License

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "standard-version": "latest"
   },
   "engines": {
-    "node": ">= 8"
+    "node": ">= 12"
   },
   "files": [
     "src"

--- a/src/index.js
+++ b/src/index.js
@@ -1,11 +1,8 @@
 'use strict'
 
-const ALPHABET = ['K', 'M', 'B', 'T']
-const TRESHOLD = 1e3
+const createCompactFormatter = locale => new Intl.NumberFormat(locale, {
+  notation: 'compact',
+  maximumFractionDigits: 1
+})
 
-module.exports = (n, fn) => {
-  let idx = 0
-  while (n >= TRESHOLD && ++idx <= ALPHABET.length) n /= TRESHOLD
-  if (fn) n = fn(n)
-  return String(idx === 0 ? n : n + ALPHABET[idx - 1])
-}
+module.exports = (n, locale = 'en-US') => createCompactFormatter(locale).format(n)

--- a/src/index.js
+++ b/src/index.js
@@ -1,8 +1,18 @@
 'use strict'
 
+const compactFormatters = new Map()
+
 const createCompactFormatter = locale => new Intl.NumberFormat(locale, {
   notation: 'compact',
   maximumFractionDigits: 1
 })
 
-module.exports = (n, locale = 'en-US') => createCompactFormatter(locale).format(n)
+const getCompactFormatter = locale => {
+  if (!compactFormatters.has(locale)) {
+    compactFormatters.set(locale, createCompactFormatter(locale))
+  }
+
+  return compactFormatters.get(locale)
+}
+
+module.exports = (n, locale = 'en-US') => getCompactFormatter(locale).format(n)

--- a/test/index.js
+++ b/test/index.js
@@ -30,3 +30,28 @@ test('compact intl support', t => {
 test('locale override support', t => {
   t.is(humanNumber(1_500, 'es-ES'), '1,5 mil')
 })
+
+test('reuses formatters per locale', t => {
+  const OriginalNumberFormat = Intl.NumberFormat
+  const seenLocales = []
+
+  Intl.NumberFormat = function (...args) {
+    seenLocales.push(args[0])
+    return new OriginalNumberFormat(...args)
+  }
+
+  try {
+    delete require.cache[require.resolve('..')]
+    const freshHumanNumber = require('..')
+
+    freshHumanNumber(1_000)
+    freshHumanNumber(2_000)
+    freshHumanNumber(1_500, 'es-ES')
+    freshHumanNumber(2_500, 'es-ES')
+  } finally {
+    Intl.NumberFormat = OriginalNumberFormat
+    delete require.cache[require.resolve('..')]
+  }
+
+  t.deepEqual(seenLocales, ['en-US', 'es-ES'])
+})

--- a/test/index.js
+++ b/test/index.js
@@ -23,9 +23,10 @@ const humanNumber = require('..')
   test(`${input} → ${output}`, t => t.is(humanNumber(input), output))
 })
 
-test('mapper support', t => {
-  t.is(
-    humanNumber(100, n => Number.parseFloat(n).toFixed(1)),
-    '100.0'
-  )
+test('compact intl support', t => {
+  t.is(humanNumber(500_000), '500K')
+})
+
+test('locale override support', t => {
+  t.is(humanNumber(1_500, 'es-ES'), '1,5 mil')
 })


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes the library’s core formatting behavior and public API, and relies on `Intl.NumberFormat` output which can vary by runtime/locale; also drops Node <12 support.
> 
> **Overview**
> Switches `human-number` from a manual `K/M/B/T` threshold algorithm (and custom mapper callback) to `Intl.NumberFormat` with `notation: 'compact'` and `maximumFractionDigits: 1`, caching formatters per locale.
> 
> Updates the API/docs to accept an optional locale (default `en-US`), adjusts tests to cover locale output and formatter reuse, and bumps the required Node engine to `>= 12`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dac1b74b2657a467fbb194ad432fcb6ddefba591. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->